### PR TITLE
Remove extra whitespace preceeding #hextris hashtag

### DIFF
--- a/js_prod_v3/view.js
+++ b/js_prod_v3/view.js
@@ -96,7 +96,7 @@ function showText(text) {
         'pausedMobile': "<div class='centeredHeader unselectable'>Paused</div><br><div class='unselectable centeredSubHeader'>Press <i class='fa fa-play'></i> to resume</div><div style='height:100px;line-height:100px;cursor:pointer;'></div>",
         'start': "<div class='centeredHeader unselectable' style='line-height:80px;'>Press enter to start</div>",
         'gameover': "<div class='centeredHeader unselectable'> Game Over: " + score + " pts</div><br><div style='font-size:24px;' class='centeredHeader unselectable'> High Scores:</div><table class='tg' style='margin:0px auto'> "
-         
+
     };
 
     if (text == 'paused') {
@@ -132,7 +132,7 @@ function showText(text) {
             }
         }
     }
-    messages['gameover'] += "<div class='fltrt' id='tweetStuff'><a class='tweet' href='https://twitter.com/intent/tweet?text=Can you beat my &button_hashtag=hextris score of "+ score +" points on http://hextris.github.io/hextris?' data-lang='en' data-related='hextris:hextris'>Share Your Score on Twitter!!!</a></div>"
+    messages['gameover'] += "<div class='fltrt' id='tweetStuff'><a class='tweet' href='https://twitter.com/intent/tweet?text=Can you beat my&button_hashtag=hextris score of "+ score +" points on http://hextris.github.io/hextris?' data-lang='en' data-related='hextris:hextris'>Share Your Score on Twitter!!!</a></div>"
     $("#overlay").html(messages[text]);
     $("#overlay").fadeIn("1000", "swing");
 


### PR DESCRIPTION
I noticed that the [`#hextris score of…` tweets](https://twitter.com/search?f=realtime&q=hextris%20score%20of&src=typd) have an extra space before them:

<img src="https://cloud.githubusercontent.com/assets/121322/3976186/f2048dee-281a-11e4-8522-712e7952858d.png" width="50%">

This Pull Request fixes it, but there may be a better approach.

**Before:** 

```
Can you beat my  #hextris score of 1337 points on http://hextris.github.io/hextris?
```

**After:** 

```
Can you beat my #hextris score of 1337 points on http://hextris.github.io/hextris?
```

Cheers,
  Lee :beers:
