### PR TITLE
Possible endgame twitch fix

### DIFF
--- a/js_v9/main.js
+++ b/js_v9/main.js
@@ -257,7 +257,6 @@ function animLoop() {
             var now = Date.now();
             var dt = (now - lastTime)/16.666 * rush;
             requestAnimFrame(animLoop);
-            update(dt);
             render();
             lastTime = now;
             break;


### PR DESCRIPTION
Gamestate == 2 is when the game is already over. Update is what moves blocks. Blocks don't need to move when the game is over and I couldn't find any reason to keep updating when the game is over. Removing update from Gamestate case 2 might fix the twitching. Needs testing.
