### PR TITLE
key 's' can be used for 'down' Closes #127

### DIFF
--- a/js_v9/input.js
+++ b/js_v9/input.js
@@ -46,6 +46,17 @@ function addKeyListeners() {
     });
 
     keypress.register_combo({
+        keys: "s",
+        on_keydown: function() {
+                rush=2;
+        },
+        on_release: function() {
+                rush=1;
+        }
+
+    });
+
+    keypress.register_combo({
         keys: "p",
         on_keydown: function(){pause();}
     });


### PR DESCRIPTION
As per usual gaming key configurations, 's' can be used in conjunction with 'a' and 'd'. It improves the ease of game play too. 

