### PR TITLE
fixed bug 

### DIFF
--- a/js/Hex.js
+++ b/js/Hex.js
@@ -32,7 +32,7 @@ function Hex(sideLength) {
 		var dy = Math.sin(angle) * obj.magnitude;
 		gdx -= dx;
 		gdy += dy;
-		obj.magnitude /= 2 * this.dt;
+		obj.magnitude -= 2 * this.dt;
 		if (obj.magnitude < 1) {
 			for (var i = 0; i < this.shakes.length; i++) {
 				if (this.shakes[i] == obj) {

--- a/js/Hex.js
+++ b/js/Hex.js
@@ -32,7 +32,7 @@ function Hex(sideLength) {
 		var dy = Math.sin(angle) * obj.magnitude;
 		gdx -= dx;
 		gdy += dy;
-		obj.magnitude -= 2 * this.dt;
+		obj.magnitude = (obj.magnitude / 2) * this.dt;
 		if (obj.magnitude < 1) {
 			for (var i = 0; i < this.shakes.length; i++) {
 				if (this.shakes[i] == obj) {

--- a/js/Hex.js
+++ b/js/Hex.js
@@ -32,7 +32,7 @@ function Hex(sideLength) {
 		var dy = Math.sin(angle) * obj.magnitude;
 		gdx -= dx;
 		gdy += dy;
-		obj.magnitude = (obj.magnitude / 2) * this.dt;
+		obj.magnitude /= 2 * (this.dt+0.5);
 		if (obj.magnitude < 1) {
 			for (var i = 0; i < this.shakes.length; i++) {
 				if (this.shakes[i] == obj) {


### PR DESCRIPTION
Fixed a bug that made the center hex escape the screen.This was caused because the magnitude of the shakes was updated through "obj.magnitude /= 2 * this.dt;".When this.dt would be less than 0.5, the magnitude would increase instead of decrease,leading the main hex to disapear from the screen due to such a high magnitude