### PR TITLE
docs: 'Contributions' lacks space

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ By:
  - Noah Moroze (@nmoroze)
  - Michael Yang (@themichaelyang)
 
-#Contributions
+# Contributions
 Please submit pull requests to clay-improvements
 
 # Releases


### PR DESCRIPTION
Very small detail, there is no space between '#' and 'contributions' which results in markdown not rendering the header appropriately.