### PR TITLE
fixed error with font-size in view.js:renderText()

### DIFF
--- a/js/view.js
+++ b/js/view.js
@@ -6,7 +6,7 @@ function easeOutCubic(t, b, c, d) {
 function renderText(x, y, fontSize, color, text, font) {
 	ctx.save();
 	if (!font) {
-		var font = '20px Exo';
+		var font = 'px Exo';
 	}
 
 	fontSize *= settings.scale;


### PR DESCRIPTION
Fixed the bug that was mentioned in Issues #182 #162 #189 The problem was that `fontSize *= settings.scale` was concatenated with `"20px Exo"` which would result in an very large fontSize. This bug would only appear if the scaled fontSize happened to result in a full integer since concatenating a float with `"20px Exo"` would only extend the digits after the decimal point. 